### PR TITLE
feat(blog): add Elixir cluster, deepen LiveView post, sort by date

### DIFF
--- a/app/blog/BlogLayout.tsx
+++ b/app/blog/BlogLayout.tsx
@@ -12,9 +12,26 @@ interface BlogLayoutProps {
 }
 
 function getRelatedPosts(currentSlug: string): BlogPost[] {
+  const current = blogPosts.find((p) => p.slug === currentSlug);
+  if (!current) return blogPosts.slice(0, 3);
+
+  const currentKeywords = new Set(
+    current.keywords.map((k) => k.toLowerCase())
+  );
+
   return blogPosts
     .filter((p) => p.slug !== currentSlug)
-    .slice(0, 3);
+    .map((p) => {
+      const sharedKeywords = p.keywords.filter((k) =>
+        currentKeywords.has(k.toLowerCase())
+      ).length;
+      const categoryBonus = p.category === current.category ? 1 : 0;
+      return { post: p, score: sharedKeywords * 2 + categoryBonus };
+    })
+    // stable sort by score desc; equal scores keep array order (fills to 3)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map((entry) => entry.post);
 }
 
 export function generateArticleJsonLd(post: BlogPost) {

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -43,6 +43,21 @@ registerContent(
   () => import("../content/phoenix-liveview-guide-2026")
 );
 
+registerContent(
+  "elixir-vs-go-2026",
+  () => import("../content/elixir-vs-go-2026")
+);
+
+registerContent(
+  "what-is-the-beam-and-otp",
+  () => import("../content/what-is-the-beam-and-otp")
+);
+
+registerContent(
+  "is-elixir-worth-learning-2026",
+  () => import("../content/is-elixir-worth-learning-2026")
+);
+
 export function generateStaticParams() {
   return getAllSlugs().map((slug) => ({ slug }));
 }

--- a/app/blog/content/elixir-phoenix-saas.tsx
+++ b/app/blog/content/elixir-phoenix-saas.tsx
@@ -78,7 +78,15 @@ export default function ElixirPhoenixSaasContent() {
       <p>
         Those constraints sound almost identical to what a modern SaaS
         application needs. That is not a coincidence&mdash;it is the reason
-        Phoenix excels where other frameworks struggle.
+        Phoenix excels where other frameworks struggle. For a deeper look at how
+        the runtime works, see our explainer on{" "}
+        <Link
+          href="/blog/what-is-the-beam-and-otp"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          the BEAM and OTP
+        </Link>
+        .
       </p>
       <p>Here is what the BEAM gives you for free:</p>
       <ul>

--- a/app/blog/content/elixir-vs-go-2026.tsx
+++ b/app/blog/content/elixir-vs-go-2026.tsx
@@ -1,0 +1,298 @@
+import Link from "next/link";
+
+export default function ElixirVsGo2026Content() {
+  return (
+    <>
+      <h2>Introduction: Two Great Concurrency Stories</h2>
+      <p>
+        <strong>Elixir vs Go</strong> is one of the more interesting backend
+        choices in 2026 because, unlike most comparisons, both languages were
+        designed for concurrency from the start&mdash;they just took opposite
+        roads. Go compiles to a single static binary and runs lightweight
+        goroutines over an efficient scheduler. Elixir runs on the{" "}
+        <a
+          href="https://www.erlang.org/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          BEAM
+        </a>
+        , the Erlang virtual machine built for telecom-grade uptime, with
+        millions of isolated processes and supervision trees. Both are excellent;
+        they optimize for different things.
+      </p>
+      <div className="rounded-xl border border-violet-500/20 bg-violet-600/10 p-6 my-6">
+        <p className="!mb-0">
+          <strong>Quick answer (TL;DR):</strong> Choose <strong>Go</strong> for
+          CPU-bound services, CLIs, infrastructure tooling, and teams that want a
+          simple, fast-compiling static binary with a huge cloud-native
+          ecosystem. Choose <strong>Elixir</strong> for real-time systems, high
+          connection counts, and fault tolerance&mdash;chat, dashboards,
+          messaging, presence&mdash;where self-healing and predictable latency
+          under load matter most.
+        </p>
+      </div>
+
+      <h2>The Core Difference: Goroutines vs the BEAM</h2>
+      <p>
+        Go runs goroutines&mdash;cheap, green threads multiplexed onto OS threads
+        by the Go runtime. They share memory, so you coordinate with channels,
+        mutexes, and the race detector. It is fast and pragmatic, but shared
+        memory means a panic in one goroutine can, if unrecovered, crash the
+        whole process.
+      </p>
+      <p>
+        The BEAM spawns millions of lightweight processes (~2&nbsp;KB each) that
+        share <em>nothing</em>&mdash;they communicate only by message passing.
+        Each process is preemptively scheduled across all cores, and a crash is
+        isolated to that one process. That isolation is the root of Elixir&rsquo;s
+        fault tolerance. To understand it fully, see our explainer on{" "}
+        <Link
+          href="/blog/what-is-the-beam-and-otp"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          what the BEAM and OTP are
+        </Link>
+        .
+      </p>
+
+      <h2>Error Handling and Fault Tolerance</h2>
+      <p>
+        Go uses explicit error values (<code>if err != nil</code>) and{" "}
+        <code>panic</code>/<code>recover</code> for exceptional cases. The style
+        is verbose but explicit&mdash;errors are impossible to ignore silently.
+      </p>
+      <p>
+        Elixir embraces &ldquo;let it crash&rdquo;: rather than defensively
+        guarding every path, you let a process fail and a supervisor restart it in
+        a known-good state. Combined with process isolation, this yields systems
+        that self-heal from transient faults&mdash;the property that keeps
+        telecom switches at nine-nines uptime.
+      </p>
+      <pre>
+        <code>{`# Elixir: a supervised worker restarts automatically on crash
+children = [
+  {MyApp.Worker, []}
+]
+
+Supervisor.start_link(children, strategy: :one_for_one)`}</code>
+      </pre>
+
+      <h2>Elixir vs Go: Side-by-Side</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Dimension</th>
+            <th>Elixir (BEAM)</th>
+            <th>Go</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Concurrency unit</td>
+            <td>Isolated processes, message passing</td>
+            <td>Goroutines, shared memory + channels</td>
+          </tr>
+          <tr>
+            <td>Fault tolerance</td>
+            <td>Supervision trees, self-healing</td>
+            <td>Manual recover; panic can crash process</td>
+          </tr>
+          <tr>
+            <td>Real-time / WebSockets</td>
+            <td>Exceptional (millions of connections)</td>
+            <td>Very good, more manual coordination</td>
+          </tr>
+          <tr>
+            <td>Raw CPU throughput</td>
+            <td>Good</td>
+            <td>Excellent (compiled, close to the metal)</td>
+          </tr>
+          <tr>
+            <td>Deployment</td>
+            <td>Releases / BEAM runtime</td>
+            <td>Single static binary</td>
+          </tr>
+          <tr>
+            <td>Ecosystem sweet spot</td>
+            <td>Web, real-time, distributed systems</td>
+            <td>Cloud-native, infra, CLIs, networking</td>
+          </tr>
+          <tr>
+            <td>Learning curve</td>
+            <td>Functional, new mental model</td>
+            <td>Small language, quick to pick up</td>
+          </tr>
+          <tr>
+            <td>Hiring pool</td>
+            <td>Smaller, senior-leaning</td>
+            <td>Large and growing</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Performance: It Depends on the Workload</h2>
+      <p>
+        For CPU-bound number crunching and tight loops, Go&rsquo;s compiled code
+        typically wins on raw throughput and lower memory per request. For
+        I/O-bound, connection-heavy, constantly-bidirectional workloads&mdash;the
+        real-time category&mdash;Elixir&rsquo;s scheduler and process model deliver
+        more predictable tail latency under load, because no single request can
+        starve the others. Benchmark your actual workload; the &ldquo;which is
+        faster&rdquo; answer flips depending on what you measure.
+      </p>
+
+      <h2>Real-Time and the Web</h2>
+      <p>
+        This is where Elixir&rsquo;s edge is clearest. With Phoenix and{" "}
+        <Link
+          href="/blog/phoenix-liveview-guide-2026"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Phoenix LiveView
+        </Link>
+        , you get channels, presence, PubSub, and server-rendered real-time UIs
+        out of the box. Go has excellent HTTP and gRPC libraries and solid
+        WebSocket support, but you assemble the real-time stack yourself. If your
+        product <em>is</em> real-time, Elixir removes more work. See also our{" "}
+        <Link
+          href="/blog/phoenix-vs-nodejs-2026"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Phoenix vs Node.js comparison
+        </Link>{" "}
+        for the same lens applied to JavaScript.
+      </p>
+
+      <h2>When to Choose Each</h2>
+      <ul>
+        <li>
+          <strong>Choose Go</strong> for microservices, infrastructure and
+          DevOps tooling, CLIs, high-throughput CPU-bound APIs, and teams that
+          value fast compilation and a single deployable binary.
+        </li>
+        <li>
+          <strong>Choose Elixir</strong> for real-time products, high concurrent
+          connection counts, systems that must stay up and self-heal, and
+          web-heavy applications where Phoenix accelerates delivery.
+        </li>
+      </ul>
+
+      <h2>Frequently Asked Questions</h2>
+
+      <h3>Is Elixir faster than Go?</h3>
+      <p>
+        Not for raw CPU-bound work&mdash;Go&rsquo;s compiled code is generally
+        faster and lighter there. Elixir shines on I/O-bound, connection-heavy
+        real-time workloads, where its scheduler gives more predictable latency
+        under heavy concurrent load. The right answer depends entirely on your
+        workload.
+      </p>
+
+      <h3>Is Go or Elixir better for real-time apps?</h3>
+      <p>
+        Elixir, in most cases. Phoenix ships channels, presence, PubSub, and
+        LiveView, and the BEAM handles enormous numbers of concurrent
+        connections. Go can absolutely build real-time systems, but you assemble
+        more of the stack yourself.
+      </p>
+
+      <h3>Which is easier to learn, Go or Elixir?</h3>
+      <p>
+        Go is easier to pick up&mdash;it is a small, imperative language with few
+        concepts. Elixir asks you to learn functional programming and the
+        actor/process model, which takes longer but pays off for concurrent,
+        fault-tolerant systems.
+      </p>
+
+      <h3>Which has better job prospects in 2026?</h3>
+      <p>
+        Go has the larger hiring pool and more listings, especially in
+        cloud-native and infrastructure roles. Elixir&rsquo;s market is smaller but
+        senior-leaning and often better paid per role. See our guide on{" "}
+        <Link
+          href="/blog/is-elixir-worth-learning-2026"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          whether Elixir is worth learning in 2026
+        </Link>
+        .
+      </p>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            mainEntity: [
+              {
+                "@type": "Question",
+                name: "Is Elixir faster than Go?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Not for raw CPU-bound work—Go's compiled code is generally faster and lighter there. Elixir shines on I/O-bound, connection-heavy real-time workloads, where its scheduler gives more predictable latency under heavy concurrent load. The right answer depends on your workload.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Is Go or Elixir better for real-time apps?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Elixir, in most cases. Phoenix ships channels, presence, PubSub, and LiveView, and the BEAM handles enormous numbers of concurrent connections. Go can build real-time systems too, but you assemble more of the stack yourself.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Which is easier to learn, Go or Elixir?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Go is easier to pick up—a small, imperative language with few concepts. Elixir asks you to learn functional programming and the actor/process model, which takes longer but pays off for concurrent, fault-tolerant systems.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Which has better job prospects in 2026?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Go has the larger hiring pool and more listings, especially in cloud-native and infrastructure roles. Elixir's market is smaller but senior-leaning and often better paid per role.",
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <h2>Building With Elixir? Talk to Equantra</h2>
+      <p>
+        Elixir Phoenix is one of our core specialties alongside Ruby on Rails,
+        Django, and Next.js. Whether you are choosing a stack for a new real-time
+        product or scaling an existing one, we can help.
+      </p>
+      <p>
+        <Link
+          href="/hire-elixir-developers"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Hire Elixir developers
+        </Link>
+        , explore our{" "}
+        <Link
+          href="/phoenix"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Phoenix framework development
+        </Link>{" "}
+        practice, or{" "}
+        <Link
+          href="/contact"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          get a free consultation
+        </Link>
+        .
+      </p>
+    </>
+  );
+}

--- a/app/blog/content/is-elixir-worth-learning-2026.tsx
+++ b/app/blog/content/is-elixir-worth-learning-2026.tsx
@@ -1,0 +1,276 @@
+import Link from "next/link";
+
+export default function IsElixirWorthLearning2026Content() {
+  return (
+    <>
+      <h2>The Short Answer</h2>
+      <p>
+        <strong>Is Elixir worth learning in 2026?</strong> For most backend and
+        full-stack developers, yes&mdash;with eyes open. Elixir will not have the
+        job volume of JavaScript, Python, or Go, but it pays well, the roles tend
+        to be senior and interesting, and the skills (functional programming,
+        concurrency, fault tolerance) make you a better engineer in every
+        language. If you want a smaller but high-quality market and genuinely
+        enjoyable tooling, it is a strong bet.
+      </p>
+      <div className="rounded-xl border border-violet-500/20 bg-violet-600/10 p-6 my-6">
+        <p className="!mb-0">
+          <strong>Learn Elixir if:</strong> you build real-time or high-concurrency
+          systems, you want to level up your understanding of concurrency and
+          reliability, or you like functional programming.{" "}
+          <strong>Maybe skip it if:</strong> you need maximum job quantity right
+          now, or your work is purely CPU-bound number crunching.
+        </p>
+      </div>
+
+      <h2>What Is Elixir Good At?</h2>
+      <p>
+        Elixir runs on the{" "}
+        <Link
+          href="/blog/what-is-the-beam-and-otp"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          BEAM virtual machine
+        </Link>
+        , which was built for systems that must stay up under massive
+        concurrency. That makes it excellent for:
+      </p>
+      <ul>
+        <li>
+          <strong>Real-time apps</strong>&mdash;chat, live dashboards,
+          collaboration, presence, notifications, with{" "}
+          <Link
+            href="/blog/phoenix-liveview-guide-2026"
+            className="text-violet-400 hover:text-violet-300 font-medium"
+          >
+            Phoenix LiveView
+          </Link>
+          .
+        </li>
+        <li>
+          <strong>High-connection systems</strong>&mdash;hundreds of thousands of
+          concurrent WebSockets on modest hardware.
+        </li>
+        <li>
+          <strong>Fault-tolerant services</strong>&mdash;systems that self-heal
+          via supervision instead of falling over.
+        </li>
+        <li>
+          <strong>Web SaaS</strong>&mdash;the Phoenix framework is productive and
+          batteries-included; see{" "}
+          <Link
+            href="/blog/why-elixir-phoenix-is-the-best-framework-for-saas"
+            className="text-violet-400 hover:text-violet-300 font-medium"
+          >
+            why Elixir Phoenix is the best framework for SaaS
+          </Link>
+          .
+        </li>
+      </ul>
+
+      <h2>Jobs and Demand in 2026</h2>
+      <p>
+        Be realistic: Elixir is a niche compared to the giants. There are fewer
+        openings, and they cluster around companies that have deliberately chosen
+        the stack&mdash;fintech, messaging, real-time products, developer tools.
+        The upside of that niche is quality: roles skew senior, teams are often
+        strong, and because supply of experienced Elixir developers is limited,
+        compensation is competitive and frequently above the median for
+        equivalent seniority in more crowded languages.
+      </p>
+      <p>
+        A practical strategy many developers use: keep a mainstream language for
+        breadth, and add Elixir for the roles and problems that genuinely value
+        it. Companies that need it often struggle to hire&mdash;which is good news
+        if you are the one who learned it.
+      </p>
+
+      <h2>Salaries</h2>
+      <p>
+        Exact numbers vary by region and seniority, but the pattern is
+        consistent: because experienced Elixir engineers are scarce, salaries
+        tend to sit at or above those for comparable roles in higher-volume
+        languages. You trade quantity of openings for quality and pay per
+        opening.
+      </p>
+
+      <h2>How Hard Is It to Learn?</h2>
+      <p>
+        The syntax is friendly&mdash;Elixir borrows Ruby&rsquo;s readability. The
+        real learning is conceptual: functional programming (immutability,
+        pattern matching, pipelines) and the actor/process model (message
+        passing, GenServers, supervision). If you come from an object-oriented
+        background, expect a few weeks of rewiring how you think. It is
+        well worth it&mdash;those concepts transfer to every language you touch
+        afterward.
+      </p>
+
+      <h2>A Learning Path</h2>
+      <ul>
+        <li>
+          <strong>Language basics:</strong> the official{" "}
+          <a
+            href="https://elixir-lang.org/getting-started/introduction.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-violet-400 hover:text-violet-300 font-medium"
+          >
+            Elixir getting-started guide
+          </a>
+          &mdash;pattern matching, pipelines, immutability.
+        </li>
+        <li>
+          <strong>Concurrency:</strong> processes, GenServer, and supervisors.
+          Our{" "}
+          <Link
+            href="/blog/what-is-the-beam-and-otp"
+            className="text-violet-400 hover:text-violet-300 font-medium"
+          >
+            BEAM and OTP explainer
+          </Link>{" "}
+          is a good conceptual primer.
+        </li>
+        <li>
+          <strong>Build something real:</strong> a Phoenix app with LiveView. The{" "}
+          <a
+            href="https://www.phoenixframework.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-violet-400 hover:text-violet-300 font-medium"
+          >
+            Phoenix framework
+          </a>{" "}
+          gives you a real-time product fast.
+        </li>
+        <li>
+          <strong>Compare and contextualize:</strong> read{" "}
+          <Link
+            href="/blog/elixir-vs-go-2026"
+            className="text-violet-400 hover:text-violet-300 font-medium"
+          >
+            Elixir vs Go
+          </Link>{" "}
+          and{" "}
+          <Link
+            href="/blog/phoenix-vs-nodejs-2026"
+            className="text-violet-400 hover:text-violet-300 font-medium"
+          >
+            Phoenix vs Node.js
+          </Link>{" "}
+          to know when to reach for it.
+        </li>
+      </ul>
+
+      <h2>Frequently Asked Questions</h2>
+
+      <h3>Is Elixir worth learning in 2026?</h3>
+      <p>
+        Yes for most backend and full-stack developers. The job market is smaller
+        than mainstream languages but pays well and skews senior, and the
+        concepts you learn&mdash;functional programming, concurrency, fault
+        tolerance&mdash;improve your engineering in every language. Skip it only if
+        you need maximum job quantity immediately or your work is purely
+        CPU-bound.
+      </p>
+
+      <h3>Are there Elixir jobs?</h3>
+      <p>
+        Yes, though fewer than for JavaScript, Python, or Go. Openings cluster
+        around companies that chose the stack deliberately&mdash;fintech,
+        messaging, real-time products, and developer tools&mdash;and tend to be
+        senior roles with competitive pay because experienced Elixir developers
+        are scarce.
+      </p>
+
+      <h3>Is Elixir hard to learn?</h3>
+      <p>
+        The syntax is approachable, especially if you know Ruby. The challenge is
+        conceptual: functional programming and the process/actor model. Expect a
+        few weeks to rewire your thinking if you come from object-oriented
+        languages&mdash;then it clicks.
+      </p>
+
+      <h3>Does Elixir pay well?</h3>
+      <p>
+        Generally yes. Because the supply of experienced Elixir engineers is
+        limited, salaries typically sit at or above those for comparable roles in
+        higher-volume languages. You trade quantity of openings for quality and
+        pay per opening.
+      </p>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            mainEntity: [
+              {
+                "@type": "Question",
+                name: "Is Elixir worth learning in 2026?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Yes for most backend and full-stack developers. The job market is smaller than mainstream languages but pays well and skews senior, and the concepts you learn—functional programming, concurrency, fault tolerance—improve your engineering in every language. Skip it only if you need maximum job quantity immediately or your work is purely CPU-bound.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Are there Elixir jobs?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Yes, though fewer than for JavaScript, Python, or Go. Openings cluster around companies that chose the stack deliberately—fintech, messaging, real-time products, and developer tools—and tend to be senior roles with competitive pay because experienced Elixir developers are scarce.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Is Elixir hard to learn?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "The syntax is approachable, especially if you know Ruby. The challenge is conceptual: functional programming and the process/actor model. Expect a few weeks to rewire your thinking if you come from object-oriented languages, then it clicks.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Does Elixir pay well?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Generally yes. Because the supply of experienced Elixir engineers is limited, salaries typically sit at or above those for comparable roles in higher-volume languages. You trade quantity of openings for quality and pay per opening.",
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <h2>Want to Work With Elixir Experts?</h2>
+      <p>
+        Elixir Phoenix is one of Equantra&rsquo;s core specialties. If you are
+        building a real-time product or scaling an existing one, we can help you
+        do it right.
+      </p>
+      <p>
+        <Link
+          href="/hire-elixir-developers"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Hire Elixir developers
+        </Link>
+        , explore our{" "}
+        <Link
+          href="/phoenix"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Phoenix framework development
+        </Link>{" "}
+        practice, or{" "}
+        <Link
+          href="/contact"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          get a free consultation
+        </Link>
+        .
+      </p>
+    </>
+  );
+}

--- a/app/blog/content/phoenix-liveview-guide-2026.tsx
+++ b/app/blog/content/phoenix-liveview-guide-2026.tsx
@@ -342,9 +342,15 @@ end`}</code>
         </li>
       </ul>
       <p>
-        The concurrency and fault-tolerance of the BEAM are exactly why LiveView
-        scales the way it does&mdash;a crashed connection is isolated and
-        supervised, not a page-wide failure.
+        The concurrency and fault-tolerance of the{" "}
+        <Link
+          href="/blog/what-is-the-beam-and-otp"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          BEAM and OTP
+        </Link>{" "}
+        are exactly why LiveView scales the way it does&mdash;a crashed
+        connection is isolated and supervised, not a page-wide failure.
       </p>
 
       <h2>When Not to Use LiveView</h2>

--- a/app/blog/content/what-is-the-beam-and-otp.tsx
+++ b/app/blog/content/what-is-the-beam-and-otp.tsx
@@ -1,0 +1,274 @@
+import Link from "next/link";
+
+export default function WhatIsTheBeamAndOtpContent() {
+  return (
+    <>
+      <h2>What Is the BEAM?</h2>
+      <p>
+        The <strong>BEAM</strong> is the virtual machine that runs Erlang and{" "}
+        <a
+          href="https://elixir-lang.org/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Elixir
+        </a>
+        . It was built at Ericsson to run telephone switches that must never go
+        down, and that heritage shapes everything about it: massive concurrency,
+        fault isolation, soft real-time latency, and hot code upgrades. When
+        people say Elixir &ldquo;scales&rdquo; and &ldquo;self-heals,&rdquo; they
+        are really talking about the BEAM.
+      </p>
+      <div className="rounded-xl border border-violet-500/20 bg-violet-600/10 p-6 my-6">
+        <p className="!mb-0">
+          <strong>In one sentence:</strong> The BEAM runs millions of tiny,
+          isolated processes that share nothing and talk only by messages, and{" "}
+          <strong>OTP</strong> is the battle-tested library of patterns
+          (GenServer, supervisors) for wiring those processes into reliable
+          systems.
+        </p>
+      </div>
+
+      <h2>Lightweight Processes, Not OS Threads</h2>
+      <p>
+        A BEAM process is not an OS process or thread. It is an extremely cheap
+        unit of concurrency&mdash;roughly 2&nbsp;KB of memory&mdash;so a single
+        machine can run millions of them at once. Each process has its own heap,
+        so garbage collection happens per-process and never pauses the whole
+        system.
+      </p>
+      <p>
+        Processes share no memory. They communicate by sending immutable
+        messages to each other&rsquo;s mailboxes. This &ldquo;shared-nothing&rdquo;
+        design is what makes concurrency on the BEAM safe by default&mdash;there
+        are no data races to guard against with locks.
+      </p>
+      <pre>
+        <code>{`# Spawn a process and send it a message
+pid = spawn(fn ->
+  receive do
+    {:hello, from} -> send(from, :hi_back)
+  end
+end)
+
+send(pid, {:hello, self()})`}</code>
+      </pre>
+
+      <h2>Preemptive Schedulers</h2>
+      <p>
+        The BEAM runs one scheduler per CPU core and multiplexes all those
+        processes across them. Crucially, scheduling is <em>preemptive</em>: the
+        VM interrupts a process after a small amount of work (reductions) so no
+        single process can hog a core and starve the others. That is why BEAM
+        systems keep low, predictable latency even under heavy load&mdash;the
+        property that matters most for real-time apps.
+      </p>
+
+      <h2>What Is OTP?</h2>
+      <p>
+        <strong>OTP</strong> (Open Telecom Platform) is the set of libraries and
+        design principles that turn raw processes into dependable systems. You
+        rarely spawn bare processes in production Elixir&mdash;you use OTP
+        abstractions, chiefly <strong>GenServer</strong> and{" "}
+        <strong>supervisors</strong>.
+      </p>
+
+      <h3>GenServer: A Stateful Process With a Contract</h3>
+      <p>
+        A GenServer is a process that holds state and responds to synchronous
+        calls and asynchronous casts through a standard set of callbacks. It is
+        the workhorse of Elixir applications&mdash;caches, counters, connection
+        pools, and background workers are all GenServers.
+      </p>
+      <pre>
+        <code>{`defmodule Counter do
+  use GenServer
+
+  def start_link(initial), do: GenServer.start_link(__MODULE__, initial, name: __MODULE__)
+  def increment, do: GenServer.cast(__MODULE__, :inc)
+  def value, do: GenServer.call(__MODULE__, :value)
+
+  @impl true
+  def init(initial), do: {:ok, initial}
+
+  @impl true
+  def handle_cast(:inc, count), do: {:noreply, count + 1}
+
+  @impl true
+  def handle_call(:value, _from, count), do: {:reply, count, count}
+end`}</code>
+      </pre>
+
+      <h3>Supervisors and &ldquo;Let It Crash&rdquo;</h3>
+      <p>
+        A supervisor is a process whose only job is to start, monitor, and
+        restart other processes. Instead of writing defensive code for every
+        possible failure, you let a process crash and trust its supervisor to
+        restart it in a clean, known-good state. Failures become isolated and
+        recoverable rather than cascading.
+      </p>
+      <pre>
+        <code>{`children = [
+  {Counter, 0},
+  {MyApp.Cache, []}
+]
+
+# If a child crashes, restart just that child
+Supervisor.start_link(children, strategy: :one_for_one)`}</code>
+      </pre>
+      <p>
+        Supervisors nest into <strong>supervision trees</strong>: supervisors
+        supervising supervisors, all the way down to workers. This tree is the
+        backbone of a fault-tolerant Elixir system. Details are in the official{" "}
+        <a
+          href="https://hexdocs.pm/elixir/supervisor-and-application.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Elixir supervisor documentation
+        </a>
+        .
+      </p>
+
+      <h2>Why This Matters for Real Products</h2>
+      <p>
+        The BEAM and OTP are exactly why{" "}
+        <Link
+          href="/blog/phoenix-liveview-guide-2026"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Phoenix LiveView
+        </Link>{" "}
+        can hold hundreds of thousands of live connections, why a dropped
+        WebSocket is a single isolated failure rather than a page-wide outage,
+        and why Elixir is such a strong fit for real-time SaaS. We make that case
+        in full in{" "}
+        <Link
+          href="/blog/why-elixir-phoenix-is-the-best-framework-for-saas"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          why Elixir Phoenix is the best framework for SaaS
+        </Link>
+        , and compare the runtime to alternatives in{" "}
+        <Link
+          href="/blog/elixir-vs-go-2026"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Elixir vs Go
+        </Link>
+        .
+      </p>
+
+      <h2>Frequently Asked Questions</h2>
+
+      <h3>What is the BEAM in Elixir?</h3>
+      <p>
+        The BEAM is the Erlang virtual machine that Elixir compiles to and runs
+        on. It provides lightweight isolated processes, per-core preemptive
+        scheduling, message passing, and fault isolation&mdash;the runtime
+        features behind Elixir&rsquo;s concurrency and reliability.
+      </p>
+
+      <h3>What is the difference between the BEAM and OTP?</h3>
+      <p>
+        The BEAM is the virtual machine&mdash;the engine that runs your code and
+        schedules processes. OTP is the library of proven patterns (GenServer,
+        supervisors, applications) built on top of the BEAM for structuring
+        reliable, fault-tolerant systems. The BEAM is the runtime; OTP is how you
+        build with it.
+      </p>
+
+      <h3>What is a GenServer?</h3>
+      <p>
+        A GenServer is an OTP behaviour for a stateful server process. It holds
+        state and handles synchronous calls and asynchronous casts through
+        standard callbacks (<code>init</code>, <code>handle_call</code>,{" "}
+        <code>handle_cast</code>). It is the most common building block in Elixir
+        applications.
+      </p>
+
+      <h3>What does &ldquo;let it crash&rdquo; mean?</h3>
+      <p>
+        &ldquo;Let it crash&rdquo; is the Elixir philosophy of not writing
+        defensive code for every error. Instead, you let a process fail and rely
+        on its supervisor to restart it in a clean state. Because processes are
+        isolated, one crash does not corrupt or take down the rest of the system.
+      </p>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            mainEntity: [
+              {
+                "@type": "Question",
+                name: "What is the BEAM in Elixir?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "The BEAM is the Erlang virtual machine that Elixir compiles to and runs on. It provides lightweight isolated processes, per-core preemptive scheduling, message passing, and fault isolation—the runtime features behind Elixir's concurrency and reliability.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "What is the difference between the BEAM and OTP?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "The BEAM is the virtual machine—the engine that runs your code and schedules processes. OTP is the library of proven patterns (GenServer, supervisors, applications) built on top of the BEAM for structuring reliable, fault-tolerant systems.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "What is a GenServer?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "A GenServer is an OTP behaviour for a stateful server process. It holds state and handles synchronous calls and asynchronous casts through standard callbacks (init, handle_call, handle_cast). It is the most common building block in Elixir applications.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "What does 'let it crash' mean?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "'Let it crash' is the Elixir philosophy of not writing defensive code for every error. Instead, you let a process fail and rely on its supervisor to restart it in a clean state. Because processes are isolated, one crash does not take down the rest of the system.",
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <h2>Build on the BEAM With Equantra</h2>
+      <p>
+        We build production Elixir Phoenix systems that lean on exactly these
+        properties&mdash;concurrency, fault tolerance, and real-time delivery.
+      </p>
+      <p>
+        <Link
+          href="/hire-elixir-developers"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Hire Elixir developers
+        </Link>
+        , explore our{" "}
+        <Link
+          href="/phoenix"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          Phoenix framework development
+        </Link>{" "}
+        practice, or{" "}
+        <Link
+          href="/contact"
+          className="text-violet-400 hover:text-violet-300 font-medium"
+        >
+          get a free consultation
+        </Link>
+        .
+      </p>
+    </>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -60,7 +60,9 @@ export default function BlogPage() {
       <section className="px-6 pb-24 flex-1">
         <div className="max-w-5xl mx-auto">
           <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-2">
-            {blogPosts.map((post) => (
+            {[...blogPosts]
+              .sort((a, b) => b.date.localeCompare(a.date))
+              .map((post) => (
               <Link
                 key={post.slug}
                 href={`/blog/${post.slug}`}

--- a/app/blog/posts.ts
+++ b/app/blog/posts.ts
@@ -139,6 +139,76 @@ export const blogPosts: BlogPost[] = [
       "phoenix framework",
     ],
   },
+  {
+    slug: "elixir-vs-go-2026",
+    title:
+      "Elixir vs Go in 2026: Concurrency, Real-Time, and Fault Tolerance Compared",
+    description:
+      "Elixir vs Go for backend development in 2026: concurrency models, error handling, real-time, performance, ecosystem, and hiring. A practical guide to choosing between them.",
+    excerpt:
+      "Elixir vs Go, compared head to head: goroutines vs the BEAM, error handling, real-time workloads, performance, and hiring. Here is how to choose the right one for your backend.",
+    date: "2026-07-11",
+    author: "Equantra",
+    readingTime: "14 min read",
+    category: "Engineering",
+    keywords: [
+      "elixir vs go",
+      "elixir vs golang",
+      "go vs elixir concurrency",
+      "beam vs goroutines",
+      "elixir real-time",
+      "backend concurrency 2026",
+      "phoenix framework",
+      "fault tolerance",
+    ],
+  },
+  {
+    slug: "what-is-the-beam-and-otp",
+    title:
+      "What Is the BEAM and OTP? Elixir's Concurrency Model Explained",
+    description:
+      "A clear explanation of the BEAM VM and OTP: lightweight processes, schedulers, GenServer, supervisors, and 'let it crash'. The foundation of Elixir and Phoenix concurrency.",
+    excerpt:
+      "The BEAM and OTP are why Elixir handles massive concurrency and self-heals from failure. Here is how processes, schedulers, GenServer, and supervision trees actually work.",
+    date: "2026-07-11",
+    author: "Equantra",
+    readingTime: "13 min read",
+    category: "Engineering",
+    keywords: [
+      "what is the beam",
+      "otp explained",
+      "genserver",
+      "what is genserver",
+      "beam vm",
+      "elixir concurrency",
+      "supervisor tree",
+      "let it crash",
+      "phoenix framework",
+    ],
+  },
+  {
+    slug: "is-elixir-worth-learning-2026",
+    title:
+      "Is Elixir Worth Learning in 2026? Jobs, Demand, and Real-World Use",
+    description:
+      "Is Elixir worth learning in 2026? An honest look at job demand, salaries, what Elixir is good at, the learning path, and who should invest in it.",
+    excerpt:
+      "Is Elixir worth learning in 2026? A practical, honest take on demand, jobs, salaries, what it is great at, and how to learn it — plus who should and should not bother.",
+    date: "2026-07-11",
+    author: "Equantra",
+    readingTime: "12 min read",
+    category: "Engineering",
+    keywords: [
+      "is elixir worth learning",
+      "learn elixir 2026",
+      "elixir jobs",
+      "elixir salary",
+      "why learn elixir",
+      "elixir demand",
+      "phoenix framework",
+      "elixir real-time",
+    ],
+  },
 ];
 
 export function getPostBySlug(slug: string): BlogPost | undefined {


### PR DESCRIPTION
Build topic authority for the Phoenix/Elixir cluster: one strong post won't rank alone.

- Add 3 long-tail posts: elixir-vs-go-2026, what-is-the-beam-and-otp, is-elixir-worth-learning-2026 (each ~2k words, FAQ + JSON-LD, authority + sibling links; auto-listed on /phoenix pillar)
- Deepen + retarget phoenix-liveview-guide-2026 (vs-React table, tutorial/testing/deployment, expanded FAQ), add lastModified
- getRelatedPosts: score by shared keywords + category, not first-3
- Blog index: sort posts by date desc so newest show first